### PR TITLE
Support for looped events

### DIFF
--- a/EventFunctionHandler.h
+++ b/EventFunctionHandler.h
@@ -30,13 +30,24 @@ class CEventFunctionHandler : public singleton<CEventFunctionHandler>
 		std::function<void(SArgumentSupportImpl*)> func;
 		size_t time{};
 		std::unique_ptr<SArgumentSupportImpl> SupportArg;
+		size_t stBaseTime{};
+		bool bLoop{false};
+		bool bIsDestroyed{false};
 
-		SFunctionHandler(std::function<void(SArgumentSupportImpl*)> _func, const size_t _time, SArgumentSupportImpl* support_arg = nullptr)
+		SFunctionHandler(std::function<void(SArgumentSupportImpl*)> _func, const size_t _time, SArgumentSupportImpl* support_arg = nullptr, const bool bloop = false)
 			: func(std::move(_func)),
-			  time(_time + get_global_time()),
-			  SupportArg(std::make_unique<SArgumentSupportImpl>(*support_arg)) {}
+			time(_time + get_global_time()),
+			SupportArg(std::make_unique<SArgumentSupportImpl>(*support_arg)),
+			stBaseTime(_time),
+			bLoop(bloop),
+			bIsDestroyed(false) {}
 
 		void UpdateTime(const size_t newtime) { time = newtime + get_global_time(); }
+
+		bool IsLooped() const { return bLoop; }
+		void SetDestoyed() { bIsDestroyed = true; }
+		bool IsDestroyed() const { return bIsDestroyed; }
+		void UpdateNextLoopTime() { time = stBaseTime + get_global_time(); }
 	};
 
 public:
@@ -44,7 +55,8 @@ public:
 	virtual ~CEventFunctionHandler() = default; // Destroy() only clears up std containers so no need to explicitly call it here
 
 	void Destroy();
-	bool AddEvent(std::function<void(SArgumentSupportImpl*)> func, const std::string_view event_name, const size_t runtime, SArgumentSupportImpl* support_arg = nullptr);
+
+	bool AddEvent(std::function<void(SArgumentSupportImpl*)> func, const std::string_view event_name, const size_t runtime, SArgumentSupportImpl* support_arg = nullptr, const bool bLoop = false);
 	void RemoveEvent(const std::string_view event_name);
 	void DelayEvent(const std::string_view event_name, const size_t newtime);
 	bool FindEvent(const std::string_view event_name) const;

--- a/README.md
+++ b/README.md
@@ -1,18 +1,25 @@
+
+### Intro
+
 ```txt
 #####################################################################################
 # ORIGINAL TOPIC: https://metin2.dev/topic/17432-reimplementation-of-events/        #
 # Created by Sherer 2017-2024 (C) - Revisioned by martysama0134 for c++20 support.  #
 #####################################################################################
-```
 
 Hello,
 
 Working on some new stuff I found out that current implementation of event looks a bit tricky.
 
-Due to this fact I basically deciced to re-implement it providing up to date tech.
+Due to this fact I basically decided to re-implement it providing up to date tech.
 
 So lets begin.
 
+That`s all.
+```
+
+
+### Implementation
 1) Add include into the `main.cpp`:
 	```cpp
 	#ifdef __NEW_EVENT_HANDLER__
@@ -61,6 +68,24 @@ So lets begin.
 	#define __NEW_EVENT_HANDLER__
 	```
 
-That`s all.
 
-Now just download [master.zip](../../archive/refs/heads/main.zip) and add the included files to your source.
+### Download
+Download [master.zip](../../archive/refs/heads/main.zip), and add the included files to your source.
+
+
+### Usage
+
+```cpp
+	// create the event (using "this" as argument is safe only if it's a singleton, for CHARACTER or CItem, use their vid and find them inside the lambda)
+	CEventFunctionHandler::instance().AddEvent([this](SArgumentSupportImpl*) {
+			this->SendNotificationToAll();
+		}, "MY_BEAUTIFUL_EVENT", std::chrono::seconds(5)
+	);
+
+	// check if it exists
+	if (CEventFunctionHandler::instance().FindEvent("MY_BEAUTIFUL_EVENT"))
+		printf("The event is active.\n");
+
+	// cancel the event (safe even if it doesn't exist)
+	CEventFunctionHandler::Instance().RemoveEvent("MY_BEAUTIFUL_EVENT");
+```


### PR DESCRIPTION
- Looped events repeatedly execute, resetting their execution time after each run.

- Normal events execute once and are removed after completion.

Usage

	CEventFunctionHandler::instance().AddEvent([this](SArgumentSupportImpl*) {
			this->SendNotificationToAll();
		}, "MY_BEAUTIFUL_EVENT", std::chrono::seconds(5).count(), nullptr, true );