### PR TITLE
Fix removal of looped event

### DIFF
--- a/EventFunctionHandler.cpp
+++ b/EventFunctionHandler.cpp
@@ -38,7 +38,7 @@ bool CEventFunctionHandler::AddEvent(std::function<void(SArgumentSupportImpl *)>
 */
 void CEventFunctionHandler::RemoveEvent(const std::string_view event_name)
 {
-	m_event.erase(event_name.data());
+	m_event_pending.emplace_back(event_name.data());
 }
 
 /*
@@ -98,6 +98,11 @@ void CEventFunctionHandler::Process()
 		}
 		return false;
 	});
+
+	for (const auto& name : m_event_pending)
+		m_event.erase(name);
+
+	m_event_pending.clear();
 }
 
 CEventFunctionHandler::SFunctionHandler * CEventFunctionHandler::GetHandlerByName(const std::string_view event_name) const

--- a/EventFunctionHandler.h
+++ b/EventFunctionHandler.h
@@ -39,15 +39,15 @@ public:
 	virtual ~CEventFunctionHandler() = default; // Destroy() only clears up std containers so no need to explicitly call it here
 
 	void Destroy();
-	bool AddEvent(std::function<void(SArgumentSupportImpl*)> func, const std::string_view event_name, const size_t time, const bool loop = false);
-	void RemoveEvent(const std::string_view event_name);
-	void DelayEvent(const std::string_view event_name, const size_t newtime);
-	bool FindEvent(const std::string_view event_name) const;
-	DWORD GetDelay(const std::string_view event_name) const;
+	bool AddEvent(std::function<void(SArgumentSupportImpl*)> func, std::string_view event_name, size_t time, bool loop = false);
+	void RemoveEvent(std::string_view event_name);
+	void DelayEvent(std::string_view event_name, size_t newtime);
+	bool FindEvent(std::string_view event_name) const;
+	DWORD GetDelay(std::string_view event_name) const;
 	void Process();
 
 private:
-	SFunctionHandler* GetHandlerByName(const std::string_view event_name) const;
+	SFunctionHandler* GetHandlerByName(std::string_view event_name) const;
 	std::vector<std::string> m_event_pending;
 	std::unordered_map<std::string, std::unique_ptr<SFunctionHandler>> m_event;
 };

--- a/EventFunctionHandler.h
+++ b/EventFunctionHandler.h
@@ -48,5 +48,6 @@ public:
 
 private:
 	SFunctionHandler* GetHandlerByName(const std::string_view event_name) const;
+	std::vector<std::string> m_event_pending;
 	std::unordered_map<std::string, std::unique_ptr<SFunctionHandler>> m_event;
 };


### PR DESCRIPTION
When the event is being looped and we try to remove it, the code will crash because it attempts to remove a non-existent event. I added a vector of events pending removal to avoid this issue.

Also I removed [unnecessary const keywords from header file](https://github.com/sndth/M2-EventFunctionHandler/commit/8f448a21ef8fd56083a9ab0c003638713bb85f1b).