### PR TITLE
feat: add pulse-based event scheduling with priority queue internals

### DIFF
--- a/EventFunctionHandler.cpp
+++ b/EventFunctionHandler.cpp
@@ -31,11 +31,6 @@ void CEventFunctionHandler::ReleaseId(const uint32_t id)
 	m_freeIds.push_back(id);
 }
 
-CEventFunctionHandler::MinHeap& CEventFunctionHandler::GetQueue(const ETimeBase timeBase)
-{
-	return timeBase == ETimeBase::Pulses ? m_pulseQueue : m_secondsQueue;
-}
-
 const CEventFunctionHandler::SEventRecord* CEventFunctionHandler::GetRecordByName(const std::string_view event_name) const
 {
 	if (const auto it = m_nameToId.find(event_name); it != m_nameToId.end())

--- a/EventFunctionHandler.cpp
+++ b/EventFunctionHandler.cpp
@@ -76,7 +76,7 @@ bool CEventFunctionHandler::AddEvent(std::function<void(SArgumentSupportImpl*)> 
 	if (m_nameToId.contains(event_name))
 		return false;
 
-	EventCallback wrappedFunc = [wrapped = std::move(func)](SArgumentSupportImpl* arg) -> long
+	EventCallback wrappedFunc = [wrapped = std::move(func)](SArgumentSupportImpl* arg) -> int32_t
 	{
 		wrapped(arg);
 		return 0;
@@ -96,7 +96,7 @@ bool CEventFunctionHandler::AddEvent(std::function<void(SArgumentSupportImpl*)> 
 	return true;
 }
 
-bool CEventFunctionHandler::AddPulseEvent(EventCallback func, const std::string_view event_name, long pulseDelay)
+bool CEventFunctionHandler::AddPulseEvent(EventCallback func, const std::string_view event_name, int32_t pulseDelay)
 {
 	if (m_nameToId.contains(event_name))
 		return false;
@@ -238,7 +238,7 @@ void CEventFunctionHandler::Process()
 
 	for (auto& [func, eventId, generation, timeBase] : collected)
 	{
-		const long result = func(nullptr);
+		const int32_t result = func(nullptr);
 
 		if (timeBase == ETimeBase::Pulses)
 		{

--- a/EventFunctionHandler.cpp
+++ b/EventFunctionHandler.cpp
@@ -8,114 +8,265 @@
 #include "config.h"
 #include "EventFunctionHandler.h"
 
-void CEventFunctionHandler::Destroy()
+uint32_t CEventFunctionHandler::AllocateId()
 {
-	m_event.clear();
+	if (!m_freeIds.empty())
+	{
+		const uint32_t id = m_freeIds.back();
+		m_freeIds.pop_back();
+		return id;
+	}
+	const uint32_t id = static_cast<uint32_t>(m_events.size());
+	m_events.emplace_back();
+	return id;
 }
 
-/*
-	AddEvent(Function_to_Call, Event_Name, Time, Loop)
-	Adding new event.
-
-	Function_to_Call - std::function object containing function called when event appears.
-	Event_Name - unique event name. If you accidently provide name of event which already exists, function returns false (if could rewrite current one but i did deny this idea).
-	Time - execution time (in sec).
-	Loop - repeat the event every Time seconds.
-*/
-bool CEventFunctionHandler::AddEvent(std::function<void(SArgumentSupportImpl *)> func, const std::string_view event_name, const size_t time, const bool loop)
+void CEventFunctionHandler::ReleaseId(const uint32_t id)
 {
-	if (GetHandlerByName(event_name))
+	auto& record = m_events[id];
+	record.active = false;
+	record.func = nullptr;
+	record.name.clear();
+	++record.generation;
+	m_freeIds.push_back(id);
+}
+
+CEventFunctionHandler::MinHeap& CEventFunctionHandler::GetQueue(const ETimeBase timeBase)
+{
+	return timeBase == ETimeBase::Pulses ? m_pulseQueue : m_secondsQueue;
+}
+
+const CEventFunctionHandler::SEventRecord* CEventFunctionHandler::GetRecordByName(const std::string_view event_name) const
+{
+	if (const auto it = m_nameToId.find(event_name); it != m_nameToId.end())
+	{
+		const auto& record = m_events[it->second];
+		if (record.active)
+			return &record;
+	}
+	return nullptr;
+}
+
+CEventFunctionHandler::SEventRecord* CEventFunctionHandler::GetRecordByName(const std::string_view event_name)
+{
+	return const_cast<SEventRecord*>(std::as_const(*this).GetRecordByName(event_name));
+}
+
+void CEventFunctionHandler::RebuildQueueIfNeeded(MinHeap& queue, const ETimeBase timeBase, const size_t staleCount)
+{
+	if (queue.empty() || staleCount * 2 <= queue.size())
+		return;
+
+	MinHeap fresh;
+	for (uint32_t id = 0; id < static_cast<uint32_t>(m_events.size()); ++id)
+	{
+		const auto& record = m_events[id];
+		if (record.active && record.timeBase == timeBase)
+			fresh.push(SHeapEntry{record.dueAt, id, record.generation});
+	}
+	queue = std::move(fresh);
+}
+
+void CEventFunctionHandler::Destroy()
+{
+	m_nameToId.clear();
+	m_events.clear();
+	m_freeIds.clear();
+	m_secondsQueue = MinHeap{};
+	m_pulseQueue = MinHeap{};
+}
+
+bool CEventFunctionHandler::AddEvent(std::function<void(SArgumentSupportImpl*)> func, const std::string_view event_name, const size_t time, const bool loop)
+{
+	if (m_nameToId.contains(event_name))
 		return false;
-	m_event.emplace(event_name, std::make_unique<SFunctionHandler>(std::move(func), time, loop));
+
+	EventCallback wrappedFunc = [wrapped = std::move(func)](SArgumentSupportImpl* arg) -> long
+	{
+		wrapped(arg);
+		return 0;
+	};
+
+	const uint32_t id = AllocateId();
+	auto& record = m_events[id];
+	record.func = std::move(wrappedFunc);
+	record.timeBase = ETimeBase::Seconds;
+	record.dueAt = get_global_time() + time;
+	record.loopTime = loop ? static_cast<int64_t>(time) : 0;
+	record.name = std::string(event_name);
+	record.active = true;
+
+	m_nameToId.emplace(record.name, id);
+	m_secondsQueue.push(SHeapEntry{record.dueAt, id, record.generation});
 	return true;
 }
 
-/*
-	RemoveEvent(Event_Name)
-	Deleting event if exists.
+bool CEventFunctionHandler::AddPulseEvent(EventCallback func, const std::string_view event_name, long pulseDelay)
+{
+	if (m_nameToId.contains(event_name))
+		return false;
 
-	Event_Name - unique event name.
-*/
+	if (pulseDelay <= 0)
+		pulseDelay = 1;
+
+	const uint32_t id = AllocateId();
+	auto& record = m_events[id];
+	record.func = std::move(func);
+	record.timeBase = ETimeBase::Pulses;
+	record.dueAt = thecore_pulse() + static_cast<size_t>(pulseDelay);
+	record.loopTime = 0;
+	record.name = std::string(event_name);
+	record.active = true;
+
+	m_nameToId.emplace(record.name, id);
+	m_pulseQueue.push(SHeapEntry{record.dueAt, id, record.generation});
+	return true;
+}
+
 void CEventFunctionHandler::RemoveEvent(const std::string_view event_name)
 {
-	if (auto it = m_event.find(event_name); it != m_event.end())
-		m_event.erase(it);
+	if (const auto it = m_nameToId.find(event_name); it != m_nameToId.end())
+	{
+		ReleaseId(it->second);
+		m_nameToId.erase(it);
+	}
 }
 
-/*
-	DelayEvent(Event_Name, NewTime)
-	Changing existing event time. Disabled for looped events.
-
-	Event_Name - unique event name.
-	NewTime - new time.
-*/
 void CEventFunctionHandler::DelayEvent(const std::string_view event_name, const size_t newtime)
 {
-	if (auto ptr = GetHandlerByName(event_name); ptr && !ptr->IsLooped())
-		ptr->UpdateTime(newtime);
+	auto* record = GetRecordByName(event_name);
+	if (!record || record->timeBase != ETimeBase::Seconds || record->loopTime != 0)
+		return;
+
+	const auto it = m_nameToId.find(event_name);
+	const uint32_t id = it->second;
+
+	++record->generation;
+	record->dueAt = get_global_time() + newtime;
+	m_secondsQueue.push(SHeapEntry{record->dueAt, id, record->generation});
 }
 
-/*
-	FindEvent(Event_Name)
-	Checking if event exists.
-
-	Event_Name - unique event name.
-*/
 bool CEventFunctionHandler::FindEvent(const std::string_view event_name) const
 {
-	return GetHandlerByName(event_name) != nullptr;
+	return GetRecordByName(event_name) != nullptr;
 }
 
-/*
-	GetDelay(Event_Name)
-	Returning event delay.
-
-	Event_Name - unique event name.
-*/
 DWORD CEventFunctionHandler::GetDelay(const std::string_view event_name) const
 {
+	const auto* record = GetRecordByName(event_name);
+	if (!record || record->timeBase != ETimeBase::Seconds)
+		return 0;
+
 	const auto current_time = get_global_time();
-	if (const auto ptr = GetHandlerByName(event_name); ptr && ptr->time >= current_time)
-		return ptr->time - current_time;
-	return 0;
+	return record->dueAt > current_time ? static_cast<DWORD>(record->dueAt - current_time) : 0;
+}
+
+DWORD CEventFunctionHandler::GetPulseDelay(const std::string_view event_name) const
+{
+	const auto* record = GetRecordByName(event_name);
+	if (!record || record->timeBase != ETimeBase::Pulses)
+		return 0;
+
+	const auto current_pulse = thecore_pulse();
+	return record->dueAt > current_pulse ? static_cast<DWORD>(record->dueAt - current_pulse) : 0;
+}
+
+bool CEventFunctionHandler::IsPulseEvent(const std::string_view event_name) const
+{
+	const auto* record = GetRecordByName(event_name);
+	return record && record->timeBase == ETimeBase::Pulses;
 }
 
 void CEventFunctionHandler::Process()
 {
-	if (m_event.empty())
+	if (m_nameToId.empty())
 		return;
 
-	const auto current_time = get_global_time();
-	std::vector<std::function<void(SArgumentSupportImpl*)>> v_function_call;
+	const auto currentSeconds = get_global_time();
+	const auto currentPulse = thecore_pulse();
 
-	std::erase_if(m_event, [&](const auto& pair)
+	struct SCollectedEvent
 	{
-		const auto& [event_name, event_fnc] = pair;
-		if (current_time >= event_fnc->time)
+		EventCallback func;
+		uint32_t eventId;
+		uint32_t generation;
+		ETimeBase timeBase;
+	};
+
+	std::vector<SCollectedEvent> collected;
+
+	auto drainQueue = [&](MinHeap& queue, const ETimeBase timeBase, const size_t now)
+	{
+		size_t staleCount = 0;
+		while (!queue.empty() && queue.top().dueAt <= now)
 		{
-			v_function_call.emplace_back(event_fnc->func);
-			if (event_fnc->IsLooped())
+			const SHeapEntry entry = queue.top();
+			queue.pop();
+
+			if (entry.eventId >= static_cast<uint32_t>(m_events.size()))
 			{
-				event_fnc->UpdateNextLoopTime();
-				return false;
+				++staleCount;
+				continue;
 			}
-			return true;
+
+			auto& record = m_events[entry.eventId];
+			if (!record.active || record.generation != entry.generation || record.timeBase != timeBase)
+			{
+				++staleCount;
+				continue;
+			}
+
+			collected.push_back(SCollectedEvent{record.func, entry.eventId, entry.generation, timeBase});
+
+			if (timeBase == ETimeBase::Seconds)
+			{
+				if (record.loopTime != 0)
+				{
+					++record.generation;
+					record.dueAt = now + static_cast<size_t>(record.loopTime);
+					queue.push(SHeapEntry{record.dueAt, entry.eventId, record.generation});
+				}
+				else
+				{
+					const auto nameIt = m_nameToId.find(record.name);
+					if (nameIt != m_nameToId.end())
+						m_nameToId.erase(nameIt);
+					ReleaseId(entry.eventId);
+				}
+			}
 		}
-		return false;
-	});
+		RebuildQueueIfNeeded(queue, timeBase, staleCount);
+	};
 
-	for (const auto& func : v_function_call)
-		func(nullptr);
-}
+	drainQueue(m_secondsQueue, ETimeBase::Seconds, currentSeconds);
+	drainQueue(m_pulseQueue, ETimeBase::Pulses, currentPulse);
 
-const CEventFunctionHandler::SFunctionHandler* CEventFunctionHandler::GetHandlerByName(const std::string_view event_name) const
-{
-	if (auto it = m_event.find(event_name); it != m_event.end())
-		return it->second.get();
-	return nullptr;
-}
+	for (auto& [func, eventId, generation, timeBase] : collected)
+	{
+		const long result = func(nullptr);
 
-CEventFunctionHandler::SFunctionHandler* CEventFunctionHandler::GetHandlerByName(const std::string_view event_name)
-{
-	return const_cast<SFunctionHandler*>(std::as_const(*this).GetHandlerByName(event_name));
+		if (timeBase == ETimeBase::Pulses)
+		{
+			if (eventId >= static_cast<uint32_t>(m_events.size()))
+				continue;
+
+			auto& record = m_events[eventId];
+			if (!record.active || record.generation != generation)
+				continue;
+
+			if (result > 0)
+			{
+				++record.generation;
+				record.dueAt = currentPulse + static_cast<size_t>(result);
+				m_pulseQueue.push(SHeapEntry{record.dueAt, eventId, record.generation});
+			}
+			else
+			{
+				const auto nameIt = m_nameToId.find(record.name);
+				if (nameIt != m_nameToId.end())
+					m_nameToId.erase(nameIt);
+				ReleaseId(eventId);
+			}
+		}
+	}
 }

--- a/EventFunctionHandler.h
+++ b/EventFunctionHandler.h
@@ -34,7 +34,7 @@ public:
 		Pulses,
 	};
 
-	using EventCallback = std::function<long(SArgumentSupportImpl*)>;
+	using EventCallback = std::function<int32_t(SArgumentSupportImpl*)>;
 
 	struct SEventRecord
 	{
@@ -66,7 +66,7 @@ public:
 
 	void Destroy();
 	bool AddEvent(std::function<void(SArgumentSupportImpl*)> func, std::string_view event_name, size_t time, bool loop = false);
-	bool AddPulseEvent(EventCallback func, std::string_view event_name, long pulseDelay);
+	bool AddPulseEvent(EventCallback func, std::string_view event_name, int32_t pulseDelay);
 	void RemoveEvent(std::string_view event_name);
 	void DelayEvent(std::string_view event_name, size_t newtime);
 	bool FindEvent(std::string_view event_name) const;

--- a/EventFunctionHandler.h
+++ b/EventFunctionHandler.h
@@ -8,6 +8,7 @@
 #include "utils.h"
 #include <cstdint>
 #include <functional>
+#include <utility>
 #include <queue>
 #include <string>
 #include <string_view>

--- a/EventFunctionHandler.h
+++ b/EventFunctionHandler.h
@@ -6,14 +6,12 @@
 
 #pragma once
 #include "utils.h"
-#include <algorithm>
 #include <cstdint>
 #include <functional>
 #include <queue>
 #include <string>
 #include <string_view>
 #include <unordered_map>
-#include <utility>
 #include <vector>
 
 struct SArgumentSupportImpl {}; // keep for v1 compatibility
@@ -80,7 +78,6 @@ public:
 private:
 	uint32_t AllocateId();
 	void ReleaseId(uint32_t id);
-	MinHeap& GetQueue(ETimeBase timeBase);
 	const SEventRecord* GetRecordByName(std::string_view event_name) const;
 	SEventRecord* GetRecordByName(std::string_view event_name);
 	void RebuildQueueIfNeeded(MinHeap& queue, ETimeBase timeBase, size_t staleCount);

--- a/EventFunctionHandler.h
+++ b/EventFunctionHandler.h
@@ -7,8 +7,9 @@
 #pragma once
 #include "utils.h"
 #include <algorithm>
+#include <cstdint>
 #include <functional>
-#include <memory>
+#include <queue>
 #include <string>
 #include <string_view>
 #include <unordered_map>
@@ -28,37 +29,65 @@ struct StringHash
 
 class CEventFunctionHandler : public singleton<CEventFunctionHandler>
 {
-	struct SFunctionHandler
+public:
+	enum class ETimeBase : uint8_t
 	{
-		std::function<void(SArgumentSupportImpl *)> func;
-		size_t time{};
-		size_t loopTime{};
-
-		SFunctionHandler(std::function<void(SArgumentSupportImpl*)> _func, const size_t _time, const bool _loop = false)
-			: func(std::move(_func)),
-			  time(_time + get_global_time()),
-			  loopTime(_loop ? _time : 0) {}
-
-		void UpdateTime(const size_t newtime) { time = newtime + get_global_time(); }
-
-		bool IsLooped() const { return loopTime != 0; }
-		void UpdateNextLoopTime() { time = loopTime + get_global_time(); }
+		Seconds,
+		Pulses,
 	};
 
-public:
+	using EventCallback = std::function<long(SArgumentSupportImpl*)>;
+
+	struct SEventRecord
+	{
+		EventCallback func;
+		ETimeBase timeBase{ETimeBase::Seconds};
+		size_t dueAt{};
+		int64_t loopTime{};
+		uint32_t generation{};
+		std::string name;
+		bool active{false};
+	};
+
+	struct SHeapEntry
+	{
+		size_t dueAt{};
+		uint32_t eventId{};
+		uint32_t generation{};
+
+		bool operator>(const SHeapEntry& rhs) const noexcept
+		{
+			return dueAt > rhs.dueAt;
+		}
+	};
+
+	using MinHeap = std::priority_queue<SHeapEntry, std::vector<SHeapEntry>, std::greater<SHeapEntry>>;
+
 	CEventFunctionHandler() = default;
-	virtual ~CEventFunctionHandler() = default; // Destroy() only clears up std containers so no need to explicitly call it here
+	virtual ~CEventFunctionHandler() = default;
 
 	void Destroy();
-	bool AddEvent(std::function<void(SArgumentSupportImpl*)> func, const std::string_view event_name, const size_t time, const bool loop = false);
-	void RemoveEvent(const std::string_view event_name);
-	void DelayEvent(const std::string_view event_name, const size_t newtime);
-	bool FindEvent(const std::string_view event_name) const;
-	DWORD GetDelay(const std::string_view event_name) const;
+	bool AddEvent(std::function<void(SArgumentSupportImpl*)> func, std::string_view event_name, size_t time, bool loop = false);
+	bool AddPulseEvent(EventCallback func, std::string_view event_name, long pulseDelay);
+	void RemoveEvent(std::string_view event_name);
+	void DelayEvent(std::string_view event_name, size_t newtime);
+	bool FindEvent(std::string_view event_name) const;
+	DWORD GetDelay(std::string_view event_name) const;
+	DWORD GetPulseDelay(std::string_view event_name) const;
+	bool IsPulseEvent(std::string_view event_name) const;
 	void Process();
 
 private:
-	const SFunctionHandler* GetHandlerByName(std::string_view event_name) const;
-	SFunctionHandler* GetHandlerByName(std::string_view event_name);
-	std::unordered_map<std::string, std::unique_ptr<SFunctionHandler>, StringHash, std::equal_to<>> m_event;
+	uint32_t AllocateId();
+	void ReleaseId(uint32_t id);
+	MinHeap& GetQueue(ETimeBase timeBase);
+	const SEventRecord* GetRecordByName(std::string_view event_name) const;
+	SEventRecord* GetRecordByName(std::string_view event_name);
+	void RebuildQueueIfNeeded(MinHeap& queue, ETimeBase timeBase, size_t staleCount);
+
+	std::unordered_map<std::string, uint32_t, StringHash, std::equal_to<>> m_nameToId;
+	std::vector<SEventRecord> m_events;
+	std::vector<uint32_t> m_freeIds;
+	MinHeap m_secondsQueue;
+	MinHeap m_pulseQueue;
 };

--- a/README.md
+++ b/README.md
@@ -1,5 +1,8 @@
+# M2-EventFunctionHandler
 
-### Intro
+[![CI](https://github.com/martysama0134/M2-EventFunctionHandler/actions/workflows/ci.yml/badge.svg)](https://github.com/martysama0134/M2-EventFunctionHandler/actions/workflows/ci.yml)
+
+A C++20 event scheduler for Metin2 game servers. Supports seconds-based timers and sub-second pulse-based events with priority-queue internals for efficient scheduling at scale.
 
 ```txt
 #####################################################################################
@@ -8,83 +11,129 @@
 #####################################################################################
 ```
 
+## Features
 
-### Implementation
-1) Add include into the `main.cpp`:
-	```cpp
+- **Seconds-based events** — one-shot or looped, with delay/reschedule support
+- **Pulse-based events** — sub-second scheduling driven by server tick (e.g. 25 Hz)
+- **10k+ event scale** — integer-ID internals, dual priority queues, O(log n) scheduling
+- **Safe re-entrancy** — collect-then-fire execution model prevents UB on self/cross-removal
+- **Zero API breakage** — existing `AddEvent` signatures unchanged
+
+## Integration
+
+1) Add include into `main.cpp`:
+```cpp
+#ifdef __NEW_EVENT_HANDLER__
+#include "EventFunctionHandler.h"
+#endif
+```
+
+2) Search for:
+```cpp
+	while (idle());
+```
+
+And add before:
+```cpp
 	#ifdef __NEW_EVENT_HANDLER__
-	#include "EventFunctionHandler.h"
+	CEventFunctionHandler EventFunctionHandler;
 	#endif
-	```
+```
 
-2) Now search for:
-	```cpp
-		while (idle());
-	```
+3) Add at the end of `idle`:
+```cpp
+	#ifdef __NEW_EVENT_HANDLER__
+	CEventFunctionHandler::instance().Process();
+	#endif
+```
 
-	And add before:
-	```cpp
-		#ifdef __NEW_EVENT_HANDLER__
-		CEventFunctionHandler EventFunctionHandler;
-		#endif
-	```
+4) Search for:
+```cpp
+	sys_log(0, "<shutdown> Destroying CArenaManager...");
+```
 
+And add before:
+```cpp
+	#ifdef __NEW_EVENT_HANDLER__
+	sys_log(0, "<shutdown> Destroying CEventFunctionHandler...");
+	CEventFunctionHandler::instance().Destroy();
+	#endif
+```
 
-3) Now add this at the end of idle:
-	```cpp
-		#ifdef __NEW_EVENT_HANDLER__
-		CEventFunctionHandler::instance().Process();
-		#endif
-	```
+5) Open `service.h` and add:
+```cpp
+#define __NEW_EVENT_HANDLER__
+```
 
+## Download
 
-
-4) Now search for:
-	```cpp
-		sys_log(0, "<shutdown> Destroying CArenaManager...");
-	```
-
-	And add before:
-	```cpp
-		#ifdef __NEW_EVENT_HANDLER__
-		sys_log(0, "<shutdown> Destroying CEventFunctionHandler...");
-		CEventFunctionHandler::instance().Destroy();
-		#endif
-	```
-
-
-5) Now open `service.h` and add this define:
-	```cpp
-	#define __NEW_EVENT_HANDLER__
-	```
-
-
-### Download
 Download [master.zip](../../archive/refs/heads/main.zip), and add the included files to your source.
 
+## Usage
 
-### Usage
+### Seconds-Based Events
 
 ```cpp
-	// Create the event and call it after 5 seconds. Using "this" as argument is safe only if it's a singleton, for CHARACTER or CItem, use their vid and find them inside the lambda.
-	CEventFunctionHandler::instance().AddEvent([this](SArgumentSupportImpl*) {
-			this->SendNotificationToAll();
-		}, "MY_BEAUTIFUL_EVENT", std::chrono::seconds(5).count()
-	);
+// One-shot event — fires once after 5 seconds
+CEventFunctionHandler::instance().AddEvent([this](SArgumentSupportImpl*) {
+		this->SendNotificationToAll();
+	}, "MY_BEAUTIFUL_EVENT", std::chrono::seconds(5).count()
+);
 
-	// Create the event and loop it every 5 minutes. Don't forget, keys already existing will be skipped, such as this one.
-	CEventFunctionHandler::instance().AddEvent([this](SArgumentSupportImpl*) {
-			this->SendNotificationToAll();
-		}, "MY_BEAUTIFUL_EVENT", std::chrono::minutes(5).count(), true
-	);
+// Looped event — repeats every 5 minutes
+CEventFunctionHandler::instance().AddEvent([this](SArgumentSupportImpl*) {
+		this->SendNotificationToAll();
+	}, "MY_BEAUTIFUL_EVENT", std::chrono::minutes(5).count(), true
+);
 
-	// Check if it exists, then delay it again by 5s. Don't forget, DelayEvent has no effect to looped events.
-	if (CEventFunctionHandler::instance().FindEvent("MY_BEAUTIFUL_EVENT"))
-		CEventFunctionHandler::instance().DelayEvent("MY_BEAUTIFUL_EVENT", std::chrono::seconds(5).count());
+// Delay a non-looped event by 5s
+if (CEventFunctionHandler::instance().FindEvent("MY_BEAUTIFUL_EVENT"))
+	CEventFunctionHandler::instance().DelayEvent("MY_BEAUTIFUL_EVENT", std::chrono::seconds(5).count());
 
-	// Get remaining time (in seconds) before the event fires. Returns 0 if already expired or not found.
-	DWORD remaining = CEventFunctionHandler::instance().GetDelay("MY_BEAUTIFUL_EVENT");
+// Get remaining time (seconds). Returns 0 if expired or not found.
+DWORD remaining = CEventFunctionHandler::instance().GetDelay("MY_BEAUTIFUL_EVENT");
 
-	// Cancel the event. Safe even if the key doesn't exist.
-	CEventFunctionHandler::instance().RemoveEvent("MY_BEAUTIFUL_EVENT");
+// Cancel the event. Safe even if the key doesn't exist.
+CEventFunctionHandler::instance().RemoveEvent("MY_BEAUTIFUL_EVENT");
 ```
+
+### Pulse-Based Events
+
+Pulse events run on the server tick (typically 25 Hz). The callback returns the next delay in pulses (`> 0` to reschedule, `<= 0` to stop).
+
+```cpp
+// One-shot pulse event — fires after 25 pulses (1 second at 25 Hz)
+CEventFunctionHandler::instance().AddPulseEvent([this](SArgumentSupportImpl*) -> long {
+		this->UpdatePosition();
+		return 0; // don't reschedule
+	}, "POSITION_UPDATE", passes_per_sec
+);
+
+// Repeating pulse event with dynamic delay
+CEventFunctionHandler::instance().AddPulseEvent([this](SArgumentSupportImpl*) -> long {
+		this->ProcessAI();
+		return passes_per_sec / 5; // reschedule every 200ms
+	}, "AI_TICK", passes_per_sec / 5
+);
+
+// Check remaining pulses
+DWORD pulses = CEventFunctionHandler::instance().GetPulseDelay("AI_TICK");
+
+// Check if an event is pulse-based
+bool isPulse = CEventFunctionHandler::instance().IsPulseEvent("AI_TICK");
+```
+
+### API Reference
+
+| Method | Description |
+|---|---|
+| `AddEvent(func, name, time, loop)` | Add seconds-based event. Returns false if name exists. |
+| `AddPulseEvent(func, name, pulseDelay)` | Add pulse-based event. Callback returns next delay. |
+| `RemoveEvent(name)` | Remove any event by name. Safe if not found. |
+| `FindEvent(name)` | Check if event exists. Works for both types. |
+| `DelayEvent(name, newtime)` | Reschedule seconds non-looped event. Ignores pulse/looped. |
+| `GetDelay(name)` | Remaining seconds. Returns 0 for pulse/missing events. |
+| `GetPulseDelay(name)` | Remaining pulses. Returns 0 for seconds/missing events. |
+| `IsPulseEvent(name)` | True if active pulse event. |
+| `Destroy()` | Clear all events and internal state. |
+| `Process()` | Fire due events. Call once per server tick. |

--- a/README.md
+++ b/README.md
@@ -103,14 +103,14 @@ Pulse events run on the server tick (typically 25 Hz). The callback returns the 
 
 ```cpp
 // One-shot pulse event — fires after 25 pulses (1 second at 25 Hz)
-CEventFunctionHandler::instance().AddPulseEvent([this](SArgumentSupportImpl*) -> long {
+CEventFunctionHandler::instance().AddPulseEvent([this](SArgumentSupportImpl*) -> int32_t {
 		this->UpdatePosition();
 		return 0; // don't reschedule
 	}, "POSITION_UPDATE", passes_per_sec
 );
 
 // Repeating pulse event with dynamic delay
-CEventFunctionHandler::instance().AddPulseEvent([this](SArgumentSupportImpl*) -> long {
+CEventFunctionHandler::instance().AddPulseEvent([this](SArgumentSupportImpl*) -> int32_t {
 		this->ProcessAI();
 		return passes_per_sec / 5; // reschedule every 200ms
 	}, "AI_TICK", passes_per_sec / 5

--- a/test/main.cpp
+++ b/test/main.cpp
@@ -255,5 +255,243 @@ int main()
 	handler.Process();
 	assert(fired_victim == 0);
 
+	// === QUERY API ===
+
+	// GetDelay returns 0 for pulse events
+	handler.Destroy();
+	set_global_time(0);
+	set_pulse(0);
+	assert(handler.AddPulseEvent([](SArgumentSupportImpl*) -> long { return 0; }, "pulse_gd", 10));
+	assert(handler.GetDelay("pulse_gd") == 0);
+
+	// GetPulseDelay returns raw pulses remaining
+	assert(handler.GetPulseDelay("pulse_gd") == 10);
+	set_pulse(3);
+	assert(handler.GetPulseDelay("pulse_gd") == 7);
+
+	// GetPulseDelay returns 0 for seconds events
+	assert(handler.AddEvent([](SArgumentSupportImpl*) {}, "sec_gpd", 10));
+	assert(handler.GetPulseDelay("sec_gpd") == 0);
+
+	// GetPulseDelay returns 0 for missing/removed events
+	assert(handler.GetPulseDelay("nonexistent") == 0);
+	handler.RemoveEvent("pulse_gd");
+	assert(handler.GetPulseDelay("pulse_gd") == 0);
+
+	// IsPulseEvent
+	handler.Destroy();
+	set_pulse(0);
+	assert(handler.AddPulseEvent([](SArgumentSupportImpl*) -> long { return 0; }, "pulse_ipe", 10));
+	assert(handler.AddEvent([](SArgumentSupportImpl*) {}, "sec_ipe", 10));
+	assert(handler.IsPulseEvent("pulse_ipe"));
+	assert(!handler.IsPulseEvent("sec_ipe"));
+	assert(!handler.IsPulseEvent("nonexistent"));
+
+	// IsPulseEvent after name reuse (pulse removed, seconds added with same name)
+	handler.RemoveEvent("pulse_ipe");
+	assert(!handler.IsPulseEvent("pulse_ipe"));
+	assert(handler.AddEvent([](SArgumentSupportImpl*) {}, "pulse_ipe", 10));
+	assert(!handler.IsPulseEvent("pulse_ipe"));
+
+	// FindEvent works for both types
+	handler.Destroy();
+	set_pulse(0);
+	assert(handler.AddPulseEvent([](SArgumentSupportImpl*) -> long { return 0; }, "pulse_fe", 10));
+	assert(handler.AddEvent([](SArgumentSupportImpl*) {}, "sec_fe", 10));
+	assert(handler.FindEvent("pulse_fe"));
+	assert(handler.FindEvent("sec_fe"));
+
+	// DelayEvent silently ignores pulse events
+	handler.Destroy();
+	set_global_time(0);
+	set_pulse(0);
+	assert(handler.AddPulseEvent([](SArgumentSupportImpl*) -> long { return 0; }, "pulse_de", 10));
+	handler.DelayEvent("pulse_de", 100);
+	assert(handler.GetPulseDelay("pulse_de") == 10);
+
+	// === MIXED ===
+
+	// Seconds + pulse coexist, fire independently
+	handler.Destroy();
+	int fired_sec_mix = 0, fired_pulse_mix = 0;
+	set_global_time(0);
+	set_pulse(0);
+	assert(handler.AddEvent([&](SArgumentSupportImpl*) { ++fired_sec_mix; }, "sec_mix", 5));
+	assert(handler.AddPulseEvent([&](SArgumentSupportImpl*) -> long { ++fired_pulse_mix; return 0; }, "pulse_mix", 10));
+	set_global_time(5);
+	set_pulse(5);
+	handler.Process();
+	assert(fired_sec_mix == 1);
+	assert(fired_pulse_mix == 0);
+	set_pulse(10);
+	handler.Process();
+	assert(fired_pulse_mix == 1);
+
+	// Same-name collision (shared namespace)
+	handler.Destroy();
+	set_pulse(0);
+	assert(handler.AddEvent([](SArgumentSupportImpl*) {}, "shared_name", 5));
+	assert(!handler.AddPulseEvent([](SArgumentSupportImpl*) -> long { return 0; }, "shared_name", 10));
+
+	// Seconds fire before pulses within same Process()
+	handler.Destroy();
+	std::vector<int> order;
+	set_global_time(0);
+	set_pulse(0);
+	assert(handler.AddPulseEvent([&](SArgumentSupportImpl*) -> long { order.push_back(2); return 0; }, "order_pulse", 5));
+	assert(handler.AddEvent([&](SArgumentSupportImpl*) { order.push_back(1); }, "order_sec", 5));
+	set_global_time(5);
+	set_pulse(5);
+	handler.Process();
+	assert(order.size() == 2);
+	assert(order[0] == 1);
+	assert(order[1] == 2);
+
+	// === EDGE CASES ===
+
+	// AddEvent with time=0 fires on next Process
+	handler.Destroy();
+	int fired_time0 = 0;
+	set_global_time(100);
+	assert(handler.AddEvent([&](SArgumentSupportImpl*) { ++fired_time0; }, "time0_event", 0));
+	handler.Process();
+	assert(fired_time0 == 1);
+
+	// AddPulseEvent with delay=0 clamped to 1
+	handler.Destroy();
+	int fired_pd0 = 0;
+	set_pulse(50);
+	assert(handler.AddPulseEvent([&](SArgumentSupportImpl*) -> long { ++fired_pd0; return 0; }, "pd0_event", 0));
+	handler.Process();
+	assert(fired_pd0 == 0);
+	set_pulse(51);
+	handler.Process();
+	assert(fired_pd0 == 1);
+
+	// Multiple pulse events same tick
+	handler.Destroy();
+	int fired_mp1 = 0, fired_mp2 = 0, fired_mp3 = 0;
+	set_pulse(0);
+	assert(handler.AddPulseEvent([&](SArgumentSupportImpl*) -> long { ++fired_mp1; return 0; }, "mp1", 5));
+	assert(handler.AddPulseEvent([&](SArgumentSupportImpl*) -> long { ++fired_mp2; return 0; }, "mp2", 5));
+	assert(handler.AddPulseEvent([&](SArgumentSupportImpl*) -> long { ++fired_mp3; return 0; }, "mp3", 5));
+	set_pulse(5);
+	handler.Process();
+	assert(fired_mp1 == 1);
+	assert(fired_mp2 == 1);
+	assert(fired_mp3 == 1);
+
+	// Callback returns negative — treated as stop
+	handler.Destroy();
+	int fired_neg = 0;
+	set_pulse(0);
+	assert(handler.AddPulseEvent([&](SArgumentSupportImpl*) -> long { ++fired_neg; return -1; }, "pulse_neg", 3));
+	set_pulse(3);
+	handler.Process();
+	assert(fired_neg == 1);
+	assert(!handler.FindEvent("pulse_neg"));
+
+	// Duplicate pulse event names rejected
+	handler.Destroy();
+	set_pulse(0);
+	assert(handler.AddPulseEvent([](SArgumentSupportImpl*) -> long { return 0; }, "dup_pulse", 5));
+	assert(!handler.AddPulseEvent([](SArgumentSupportImpl*) -> long { return 0; }, "dup_pulse", 10));
+
+	// === STALE / LIFECYCLE ===
+
+	// Remove + re-add same name — old heap entry doesn't fire new event
+	handler.Destroy();
+	int fired_old = 0, fired_new = 0;
+	set_pulse(0);
+	assert(handler.AddPulseEvent([&](SArgumentSupportImpl*) -> long { ++fired_old; return 0; }, "stale_test", 5));
+	handler.RemoveEvent("stale_test");
+	assert(handler.AddPulseEvent([&](SArgumentSupportImpl*) -> long { ++fired_new; return 0; }, "stale_test", 10));
+	set_pulse(5);
+	handler.Process();
+	assert(fired_old == 0);
+	assert(fired_new == 0);
+	set_pulse(10);
+	handler.Process();
+	assert(fired_old == 0);
+	assert(fired_new == 1);
+
+	// Looped seconds callback removes itself
+	handler.Destroy();
+	int fired_loop_selfrem = 0;
+	set_global_time(0);
+	assert(handler.AddEvent([&](SArgumentSupportImpl*) {
+		++fired_loop_selfrem;
+		handler.RemoveEvent("loop_selfrem");
+	}, "loop_selfrem", 3, true));
+	set_global_time(3);
+	handler.Process();
+	assert(fired_loop_selfrem == 1);
+	assert(!handler.FindEvent("loop_selfrem"));
+	set_global_time(6);
+	handler.Process();
+	assert(fired_loop_selfrem == 1);
+
+	// Destroy clears all structures including queues
+	handler.Destroy();
+	set_pulse(0);
+	assert(handler.AddPulseEvent([](SArgumentSupportImpl*) -> long { return 5; }, "destroy_p", 3));
+	assert(handler.AddEvent([](SArgumentSupportImpl*) {}, "destroy_s", 3));
+	handler.Destroy();
+	assert(!handler.FindEvent("destroy_p"));
+	assert(!handler.FindEvent("destroy_s"));
+
+	// External RemoveEvent on pending pulse event
+	handler.Destroy();
+	int fired_ext_rem = 0;
+	set_pulse(0);
+	assert(handler.AddPulseEvent([&](SArgumentSupportImpl*) -> long { ++fired_ext_rem; return 0; }, "ext_rem_pulse", 5));
+	handler.RemoveEvent("ext_rem_pulse");
+	set_pulse(5);
+	handler.Process();
+	assert(fired_ext_rem == 0);
+
+	// === SCALE ===
+
+	// 1000+ events with mixed adds, removes, reschedules
+	handler.Destroy();
+	set_global_time(0);
+	set_pulse(0);
+
+	constexpr int SCALE_COUNT = 1200;
+	int scale_sec_fired = 0;
+	int scale_pulse_fired = 0;
+
+	for (int i = 0; i < SCALE_COUNT; ++i)
+	{
+		const std::string sec_name = "scale_sec_" + std::to_string(i);
+		const std::string pulse_name = "scale_pulse_" + std::to_string(i);
+		assert(handler.AddEvent([&](SArgumentSupportImpl*) { ++scale_sec_fired; }, sec_name, 10));
+		assert(handler.AddPulseEvent([&](SArgumentSupportImpl*) -> long { ++scale_pulse_fired; return 0; }, pulse_name, 25));
+	}
+
+	// Remove every other one
+	for (int i = 0; i < SCALE_COUNT; i += 2)
+	{
+		handler.RemoveEvent("scale_sec_" + std::to_string(i));
+		handler.RemoveEvent("scale_pulse_" + std::to_string(i));
+	}
+
+	set_global_time(10);
+	set_pulse(25);
+	handler.Process();
+
+	assert(scale_sec_fired == SCALE_COUNT / 2);
+	assert(scale_pulse_fired == SCALE_COUNT / 2);
+
+	// All should be gone now (one-shot)
+	for (int i = 0; i < SCALE_COUNT; ++i)
+	{
+		assert(!handler.FindEvent("scale_sec_" + std::to_string(i)));
+		assert(!handler.FindEvent("scale_pulse_" + std::to_string(i)));
+	}
+
+	handler.Destroy();
+
 	return 0;
 }
+

--- a/test/main.cpp
+++ b/test/main.cpp
@@ -126,7 +126,7 @@ int main()
 	int fired_pulse = 0;
 	set_global_time(0);
 	set_pulse(0);
-	assert(handler.AddPulseEvent([&](SArgumentSupportImpl*) -> long { ++fired_pulse; return 0; }, "pulse_once", 10));
+	assert(handler.AddPulseEvent([&](SArgumentSupportImpl*) -> int32_t { ++fired_pulse; return 0; }, "pulse_once", 10));
 	set_pulse(9);
 	handler.Process();
 	assert(fired_pulse == 0);
@@ -139,7 +139,7 @@ int main()
 	handler.Destroy();
 	int fired_resched = 0;
 	set_pulse(0);
-	assert(handler.AddPulseEvent([&](SArgumentSupportImpl*) -> long { ++fired_resched; return 5; }, "pulse_resched", 10));
+	assert(handler.AddPulseEvent([&](SArgumentSupportImpl*) -> int32_t { ++fired_resched; return 5; }, "pulse_resched", 10));
 	set_pulse(10);
 	handler.Process();
 	assert(fired_resched == 1);
@@ -155,7 +155,7 @@ int main()
 	handler.Destroy();
 	int dynamic_count = 0;
 	set_pulse(0);
-	assert(handler.AddPulseEvent([&](SArgumentSupportImpl*) -> long {
+	assert(handler.AddPulseEvent([&](SArgumentSupportImpl*) -> int32_t {
 		++dynamic_count;
 		if (dynamic_count == 1) return 10;
 		if (dynamic_count == 2) return 5;
@@ -176,7 +176,7 @@ int main()
 	handler.Destroy();
 	int fired_offbyone = 0;
 	set_pulse(100);
-	assert(handler.AddPulseEvent([&](SArgumentSupportImpl*) -> long { ++fired_offbyone; return 0; }, "pulse_obo", 1));
+	assert(handler.AddPulseEvent([&](SArgumentSupportImpl*) -> int32_t { ++fired_offbyone; return 0; }, "pulse_obo", 1));
 	handler.Process();
 	assert(fired_offbyone == 0);
 	set_pulse(101);
@@ -189,7 +189,7 @@ int main()
 	handler.Destroy();
 	int fired_selfrem = 0;
 	set_pulse(0);
-	assert(handler.AddPulseEvent([&](SArgumentSupportImpl*) -> long {
+	assert(handler.AddPulseEvent([&](SArgumentSupportImpl*) -> int32_t {
 		++fired_selfrem;
 		handler.RemoveEvent("pulse_selfrem");
 		return 5;
@@ -206,10 +206,10 @@ int main()
 	handler.Destroy();
 	int fired_readd_orig = 0, fired_readd_new = 0;
 	set_pulse(0);
-	assert(handler.AddPulseEvent([&](SArgumentSupportImpl*) -> long {
+	assert(handler.AddPulseEvent([&](SArgumentSupportImpl*) -> int32_t {
 		++fired_readd_orig;
 		handler.RemoveEvent("pulse_readd");
-		handler.AddPulseEvent([&](SArgumentSupportImpl*) -> long { ++fired_readd_new; return 0; }, "pulse_readd", 5);
+		handler.AddPulseEvent([&](SArgumentSupportImpl*) -> int32_t { ++fired_readd_new; return 0; }, "pulse_readd", 5);
 		return 0;
 	}, "pulse_readd", 3));
 	set_pulse(3);
@@ -225,8 +225,8 @@ int main()
 	handler.Destroy();
 	int fired_delay0 = 0;
 	set_pulse(0);
-	assert(handler.AddPulseEvent([&](SArgumentSupportImpl*) -> long {
-		handler.AddPulseEvent([&](SArgumentSupportImpl*) -> long { ++fired_delay0; return 0; }, "pulse_delay0_child", 0);
+	assert(handler.AddPulseEvent([&](SArgumentSupportImpl*) -> int32_t {
+		handler.AddPulseEvent([&](SArgumentSupportImpl*) -> int32_t { ++fired_delay0; return 0; }, "pulse_delay0_child", 0);
 		return 0;
 	}, "pulse_delay0_parent", 5));
 	set_pulse(5);
@@ -241,8 +241,8 @@ int main()
 	handler.Destroy();
 	int fired_victim = 0, fired_killer = 0;
 	set_pulse(0);
-	assert(handler.AddPulseEvent([&](SArgumentSupportImpl*) -> long { ++fired_victim; return 0; }, "pulse_victim", 10));
-	assert(handler.AddPulseEvent([&](SArgumentSupportImpl*) -> long {
+	assert(handler.AddPulseEvent([&](SArgumentSupportImpl*) -> int32_t { ++fired_victim; return 0; }, "pulse_victim", 10));
+	assert(handler.AddPulseEvent([&](SArgumentSupportImpl*) -> int32_t {
 		++fired_killer;
 		handler.RemoveEvent("pulse_victim");
 		return 0;
@@ -261,7 +261,7 @@ int main()
 	handler.Destroy();
 	set_global_time(0);
 	set_pulse(0);
-	assert(handler.AddPulseEvent([](SArgumentSupportImpl*) -> long { return 0; }, "pulse_gd", 10));
+	assert(handler.AddPulseEvent([](SArgumentSupportImpl*) -> int32_t { return 0; }, "pulse_gd", 10));
 	assert(handler.GetDelay("pulse_gd") == 0);
 
 	// GetPulseDelay returns raw pulses remaining
@@ -281,7 +281,7 @@ int main()
 	// IsPulseEvent
 	handler.Destroy();
 	set_pulse(0);
-	assert(handler.AddPulseEvent([](SArgumentSupportImpl*) -> long { return 0; }, "pulse_ipe", 10));
+	assert(handler.AddPulseEvent([](SArgumentSupportImpl*) -> int32_t { return 0; }, "pulse_ipe", 10));
 	assert(handler.AddEvent([](SArgumentSupportImpl*) {}, "sec_ipe", 10));
 	assert(handler.IsPulseEvent("pulse_ipe"));
 	assert(!handler.IsPulseEvent("sec_ipe"));
@@ -296,7 +296,7 @@ int main()
 	// FindEvent works for both types
 	handler.Destroy();
 	set_pulse(0);
-	assert(handler.AddPulseEvent([](SArgumentSupportImpl*) -> long { return 0; }, "pulse_fe", 10));
+	assert(handler.AddPulseEvent([](SArgumentSupportImpl*) -> int32_t { return 0; }, "pulse_fe", 10));
 	assert(handler.AddEvent([](SArgumentSupportImpl*) {}, "sec_fe", 10));
 	assert(handler.FindEvent("pulse_fe"));
 	assert(handler.FindEvent("sec_fe"));
@@ -305,7 +305,7 @@ int main()
 	handler.Destroy();
 	set_global_time(0);
 	set_pulse(0);
-	assert(handler.AddPulseEvent([](SArgumentSupportImpl*) -> long { return 0; }, "pulse_de", 10));
+	assert(handler.AddPulseEvent([](SArgumentSupportImpl*) -> int32_t { return 0; }, "pulse_de", 10));
 	handler.DelayEvent("pulse_de", 100);
 	assert(handler.GetPulseDelay("pulse_de") == 10);
 
@@ -317,7 +317,7 @@ int main()
 	set_global_time(0);
 	set_pulse(0);
 	assert(handler.AddEvent([&](SArgumentSupportImpl*) { ++fired_sec_mix; }, "sec_mix", 5));
-	assert(handler.AddPulseEvent([&](SArgumentSupportImpl*) -> long { ++fired_pulse_mix; return 0; }, "pulse_mix", 10));
+	assert(handler.AddPulseEvent([&](SArgumentSupportImpl*) -> int32_t { ++fired_pulse_mix; return 0; }, "pulse_mix", 10));
 	set_global_time(5);
 	set_pulse(5);
 	handler.Process();
@@ -331,14 +331,14 @@ int main()
 	handler.Destroy();
 	set_pulse(0);
 	assert(handler.AddEvent([](SArgumentSupportImpl*) {}, "shared_name", 5));
-	assert(!handler.AddPulseEvent([](SArgumentSupportImpl*) -> long { return 0; }, "shared_name", 10));
+	assert(!handler.AddPulseEvent([](SArgumentSupportImpl*) -> int32_t { return 0; }, "shared_name", 10));
 
 	// Seconds fire before pulses within same Process()
 	handler.Destroy();
 	std::vector<int> order;
 	set_global_time(0);
 	set_pulse(0);
-	assert(handler.AddPulseEvent([&](SArgumentSupportImpl*) -> long { order.push_back(2); return 0; }, "order_pulse", 5));
+	assert(handler.AddPulseEvent([&](SArgumentSupportImpl*) -> int32_t { order.push_back(2); return 0; }, "order_pulse", 5));
 	assert(handler.AddEvent([&](SArgumentSupportImpl*) { order.push_back(1); }, "order_sec", 5));
 	set_global_time(5);
 	set_pulse(5);
@@ -361,7 +361,7 @@ int main()
 	handler.Destroy();
 	int fired_pd0 = 0;
 	set_pulse(50);
-	assert(handler.AddPulseEvent([&](SArgumentSupportImpl*) -> long { ++fired_pd0; return 0; }, "pd0_event", 0));
+	assert(handler.AddPulseEvent([&](SArgumentSupportImpl*) -> int32_t { ++fired_pd0; return 0; }, "pd0_event", 0));
 	handler.Process();
 	assert(fired_pd0 == 0);
 	set_pulse(51);
@@ -372,9 +372,9 @@ int main()
 	handler.Destroy();
 	int fired_mp1 = 0, fired_mp2 = 0, fired_mp3 = 0;
 	set_pulse(0);
-	assert(handler.AddPulseEvent([&](SArgumentSupportImpl*) -> long { ++fired_mp1; return 0; }, "mp1", 5));
-	assert(handler.AddPulseEvent([&](SArgumentSupportImpl*) -> long { ++fired_mp2; return 0; }, "mp2", 5));
-	assert(handler.AddPulseEvent([&](SArgumentSupportImpl*) -> long { ++fired_mp3; return 0; }, "mp3", 5));
+	assert(handler.AddPulseEvent([&](SArgumentSupportImpl*) -> int32_t { ++fired_mp1; return 0; }, "mp1", 5));
+	assert(handler.AddPulseEvent([&](SArgumentSupportImpl*) -> int32_t { ++fired_mp2; return 0; }, "mp2", 5));
+	assert(handler.AddPulseEvent([&](SArgumentSupportImpl*) -> int32_t { ++fired_mp3; return 0; }, "mp3", 5));
 	set_pulse(5);
 	handler.Process();
 	assert(fired_mp1 == 1);
@@ -385,7 +385,7 @@ int main()
 	handler.Destroy();
 	int fired_neg = 0;
 	set_pulse(0);
-	assert(handler.AddPulseEvent([&](SArgumentSupportImpl*) -> long { ++fired_neg; return -1; }, "pulse_neg", 3));
+	assert(handler.AddPulseEvent([&](SArgumentSupportImpl*) -> int32_t { ++fired_neg; return -1; }, "pulse_neg", 3));
 	set_pulse(3);
 	handler.Process();
 	assert(fired_neg == 1);
@@ -394,8 +394,8 @@ int main()
 	// Duplicate pulse event names rejected
 	handler.Destroy();
 	set_pulse(0);
-	assert(handler.AddPulseEvent([](SArgumentSupportImpl*) -> long { return 0; }, "dup_pulse", 5));
-	assert(!handler.AddPulseEvent([](SArgumentSupportImpl*) -> long { return 0; }, "dup_pulse", 10));
+	assert(handler.AddPulseEvent([](SArgumentSupportImpl*) -> int32_t { return 0; }, "dup_pulse", 5));
+	assert(!handler.AddPulseEvent([](SArgumentSupportImpl*) -> int32_t { return 0; }, "dup_pulse", 10));
 
 	// === STALE / LIFECYCLE ===
 
@@ -403,9 +403,9 @@ int main()
 	handler.Destroy();
 	int fired_old = 0, fired_new = 0;
 	set_pulse(0);
-	assert(handler.AddPulseEvent([&](SArgumentSupportImpl*) -> long { ++fired_old; return 0; }, "stale_test", 5));
+	assert(handler.AddPulseEvent([&](SArgumentSupportImpl*) -> int32_t { ++fired_old; return 0; }, "stale_test", 5));
 	handler.RemoveEvent("stale_test");
-	assert(handler.AddPulseEvent([&](SArgumentSupportImpl*) -> long { ++fired_new; return 0; }, "stale_test", 10));
+	assert(handler.AddPulseEvent([&](SArgumentSupportImpl*) -> int32_t { ++fired_new; return 0; }, "stale_test", 10));
 	set_pulse(5);
 	handler.Process();
 	assert(fired_old == 0);
@@ -434,7 +434,7 @@ int main()
 	// Destroy clears all structures including queues
 	handler.Destroy();
 	set_pulse(0);
-	assert(handler.AddPulseEvent([](SArgumentSupportImpl*) -> long { return 5; }, "destroy_p", 3));
+	assert(handler.AddPulseEvent([](SArgumentSupportImpl*) -> int32_t { return 5; }, "destroy_p", 3));
 	assert(handler.AddEvent([](SArgumentSupportImpl*) {}, "destroy_s", 3));
 	handler.Destroy();
 	assert(!handler.FindEvent("destroy_p"));
@@ -450,7 +450,7 @@ int main()
 		handler.Destroy();
 		handler.AddEvent([&](SArgumentSupportImpl*) { ++fired_destroy_added; }, "post_destroy_event", 5);
 	}, "destroy_caller", 3));
-	assert(handler.AddPulseEvent([&](SArgumentSupportImpl*) -> long { ++fired_destroy_cb2; return 5; }, "destroy_victim", 3));
+	assert(handler.AddPulseEvent([&](SArgumentSupportImpl*) -> int32_t { ++fired_destroy_cb2; return 5; }, "destroy_victim", 3));
 	set_global_time(3);
 	set_pulse(3);
 	handler.Process();
@@ -467,7 +467,7 @@ int main()
 	handler.Destroy();
 	int fired_ext_rem = 0;
 	set_pulse(0);
-	assert(handler.AddPulseEvent([&](SArgumentSupportImpl*) -> long { ++fired_ext_rem; return 0; }, "ext_rem_pulse", 5));
+	assert(handler.AddPulseEvent([&](SArgumentSupportImpl*) -> int32_t { ++fired_ext_rem; return 0; }, "ext_rem_pulse", 5));
 	handler.RemoveEvent("ext_rem_pulse");
 	set_pulse(5);
 	handler.Process();
@@ -489,7 +489,7 @@ int main()
 		const std::string sec_name = "scale_sec_" + std::to_string(i);
 		const std::string pulse_name = "scale_pulse_" + std::to_string(i);
 		assert(handler.AddEvent([&](SArgumentSupportImpl*) { ++scale_sec_fired; }, sec_name, 10));
-		assert(handler.AddPulseEvent([&](SArgumentSupportImpl*) -> long { ++scale_pulse_fired; return 0; }, pulse_name, 25));
+		assert(handler.AddPulseEvent([&](SArgumentSupportImpl*) -> int32_t { ++scale_pulse_fired; return 0; }, pulse_name, 25));
 	}
 
 	// Remove every other one

--- a/test/main.cpp
+++ b/test/main.cpp
@@ -440,6 +440,29 @@ int main()
 	assert(!handler.FindEvent("destroy_p"));
 	assert(!handler.FindEvent("destroy_s"));
 
+	// Destroy during callback — remaining callbacks fire, new adds go to fresh state
+	handler.Destroy();
+	int fired_destroy_cb1 = 0, fired_destroy_cb2 = 0, fired_destroy_added = 0;
+	set_global_time(0);
+	set_pulse(0);
+	assert(handler.AddEvent([&](SArgumentSupportImpl*) {
+		++fired_destroy_cb1;
+		handler.Destroy();
+		handler.AddEvent([&](SArgumentSupportImpl*) { ++fired_destroy_added; }, "post_destroy_event", 5);
+	}, "destroy_caller", 3));
+	assert(handler.AddPulseEvent([&](SArgumentSupportImpl*) -> long { ++fired_destroy_cb2; return 5; }, "destroy_victim", 3));
+	set_global_time(3);
+	set_pulse(3);
+	handler.Process();
+	assert(fired_destroy_cb1 == 1);
+	assert(fired_destroy_cb2 == 1);
+	assert(handler.FindEvent("post_destroy_event"));
+	assert(!handler.FindEvent("destroy_caller"));
+	assert(!handler.FindEvent("destroy_victim"));
+	set_global_time(8);
+	handler.Process();
+	assert(fired_destroy_added == 1);
+
 	// External RemoveEvent on pending pulse event
 	handler.Destroy();
 	int fired_ext_rem = 0;

--- a/test/main.cpp
+++ b/test/main.cpp
@@ -1,4 +1,5 @@
 #include "EventFunctionHandler.h"
+#include "config.h"
 #include <cassert>
 #include <string>
 
@@ -117,6 +118,142 @@ int main()
 	// Destroy clears all
 	handler.Destroy();
 	assert(!handler.FindEvent("remover"));
+
+	// === PULSE BASICS ===
+
+	// AddPulseEvent fires at correct pulse
+	handler.Destroy();
+	int fired_pulse = 0;
+	set_global_time(0);
+	set_pulse(0);
+	assert(handler.AddPulseEvent([&](SArgumentSupportImpl*) -> long { ++fired_pulse; return 0; }, "pulse_once", 10));
+	set_pulse(9);
+	handler.Process();
+	assert(fired_pulse == 0);
+	set_pulse(10);
+	handler.Process();
+	assert(fired_pulse == 1);
+	assert(!handler.FindEvent("pulse_once"));
+
+	// Return > 0 reschedules
+	handler.Destroy();
+	int fired_resched = 0;
+	set_pulse(0);
+	assert(handler.AddPulseEvent([&](SArgumentSupportImpl*) -> long { ++fired_resched; return 5; }, "pulse_resched", 10));
+	set_pulse(10);
+	handler.Process();
+	assert(fired_resched == 1);
+	assert(handler.FindEvent("pulse_resched"));
+	set_pulse(14);
+	handler.Process();
+	assert(fired_resched == 1);
+	set_pulse(15);
+	handler.Process();
+	assert(fired_resched == 2);
+
+	// Dynamic delay — different return each invocation
+	handler.Destroy();
+	int dynamic_count = 0;
+	set_pulse(0);
+	assert(handler.AddPulseEvent([&](SArgumentSupportImpl*) -> long {
+		++dynamic_count;
+		if (dynamic_count == 1) return 10;
+		if (dynamic_count == 2) return 5;
+		return 0;
+	}, "pulse_dynamic", 3));
+	set_pulse(3);
+	handler.Process();
+	assert(dynamic_count == 1);
+	set_pulse(13);
+	handler.Process();
+	assert(dynamic_count == 2);
+	set_pulse(18);
+	handler.Process();
+	assert(dynamic_count == 3);
+	assert(!handler.FindEvent("pulse_dynamic"));
+
+	// Off-by-one: delay 1 fires at N+1
+	handler.Destroy();
+	int fired_offbyone = 0;
+	set_pulse(100);
+	assert(handler.AddPulseEvent([&](SArgumentSupportImpl*) -> long { ++fired_offbyone; return 0; }, "pulse_obo", 1));
+	handler.Process();
+	assert(fired_offbyone == 0);
+	set_pulse(101);
+	handler.Process();
+	assert(fired_offbyone == 1);
+
+	// === PULSE SAFETY ===
+
+	// Pulse self-remove from callback
+	handler.Destroy();
+	int fired_selfrem = 0;
+	set_pulse(0);
+	assert(handler.AddPulseEvent([&](SArgumentSupportImpl*) -> long {
+		++fired_selfrem;
+		handler.RemoveEvent("pulse_selfrem");
+		return 5;
+	}, "pulse_selfrem", 3));
+	set_pulse(3);
+	handler.Process();
+	assert(fired_selfrem == 1);
+	assert(!handler.FindEvent("pulse_selfrem"));
+	set_pulse(100);
+	handler.Process();
+	assert(fired_selfrem == 1);
+
+	// Re-add same name from inside pulse callback
+	handler.Destroy();
+	int fired_readd_orig = 0, fired_readd_new = 0;
+	set_pulse(0);
+	assert(handler.AddPulseEvent([&](SArgumentSupportImpl*) -> long {
+		++fired_readd_orig;
+		handler.RemoveEvent("pulse_readd");
+		handler.AddPulseEvent([&](SArgumentSupportImpl*) -> long { ++fired_readd_new; return 0; }, "pulse_readd", 5);
+		return 0;
+	}, "pulse_readd", 3));
+	set_pulse(3);
+	handler.Process();
+	assert(fired_readd_orig == 1);
+	assert(handler.FindEvent("pulse_readd"));
+	assert(fired_readd_new == 0);
+	set_pulse(8);
+	handler.Process();
+	assert(fired_readd_new == 1);
+
+	// Callback adds pulse event with delay 0 (clamped to 1)
+	handler.Destroy();
+	int fired_delay0 = 0;
+	set_pulse(0);
+	assert(handler.AddPulseEvent([&](SArgumentSupportImpl*) -> long {
+		handler.AddPulseEvent([&](SArgumentSupportImpl*) -> long { ++fired_delay0; return 0; }, "pulse_delay0_child", 0);
+		return 0;
+	}, "pulse_delay0_parent", 5));
+	set_pulse(5);
+	handler.Process();
+	assert(fired_delay0 == 0);
+	assert(handler.FindEvent("pulse_delay0_child"));
+	set_pulse(6);
+	handler.Process();
+	assert(fired_delay0 == 1);
+
+	// Callback removes a different pulse event
+	handler.Destroy();
+	int fired_victim = 0, fired_killer = 0;
+	set_pulse(0);
+	assert(handler.AddPulseEvent([&](SArgumentSupportImpl*) -> long { ++fired_victim; return 0; }, "pulse_victim", 10));
+	assert(handler.AddPulseEvent([&](SArgumentSupportImpl*) -> long {
+		++fired_killer;
+		handler.RemoveEvent("pulse_victim");
+		return 0;
+	}, "pulse_killer", 5));
+	set_pulse(5);
+	handler.Process();
+	assert(fired_killer == 1);
+	assert(!handler.FindEvent("pulse_victim"));
+	set_pulse(10);
+	handler.Process();
+	assert(fired_victim == 0);
 
 	return 0;
 }

--- a/test/stubs/config.h
+++ b/test/stubs/config.h
@@ -1,4 +1,5 @@
 #pragma once
+#include <cstddef>
 
 inline int passes_per_sec = 25;
 inline size_t g_test_pulse = 0;

--- a/test/stubs/config.h
+++ b/test/stubs/config.h
@@ -1,1 +1,6 @@
 #pragma once
+
+inline int passes_per_sec = 25;
+inline size_t g_test_pulse = 0;
+inline size_t thecore_pulse() noexcept { return g_test_pulse; }
+inline void set_pulse(size_t p) noexcept { g_test_pulse = p; }


### PR DESCRIPTION
## Summary

- **Pulse events**: new `AddPulseEvent` API for sub-second tick-based scheduling (callback returns next delay, `<= 0` stops)
- **Rewritten internals**: integer-ID flat vector + free list replaces `unordered_map<string, unique_ptr>`, dual priority queues (seconds + pulses) replace linear scan, generation-based stale detection
- **New query API**: `GetPulseDelay`, `IsPulseEvent` for pulse event introspection
- **40+ tests**: pulse basics, safety (self-remove, cross-remove, re-add from callback), query API, mixed seconds+pulse, edge cases, Destroy-during-callback, 1200-event scale test
- **Zero API breakage**: existing `AddEvent` signatures unchanged, `int32_t` used instead of `long` for cross-platform consistency
- **Updated README**: CI badge, pulse usage examples, API reference table

## Design

Supersedes #6 (same goal, safe execution). Key differences from #6:
- Collect-then-fire `Process()` model prevents UB on self/cross-removal
- 16-byte heap entries (integer ID) vs 32+ byte (string key)
- `Destroy()` clears all structures including queues
- Comprehensive test coverage

## Test plan

- [x] All existing seconds-based tests pass unchanged
- [x] Pulse fire timing, reschedule, dynamic delay, off-by-one
- [x] Self-remove, cross-remove, re-add from callback, delay-0 clamp
- [x] GetDelay/GetPulseDelay/IsPulseEvent/FindEvent/DelayEvent on both types
- [x] Seconds fire before pulses ordering
- [x] Destroy during callback safety
- [x] 1200-event scale with mixed adds/removes
- [x] Local MSVC build passes
- [ ] CI matrix: gcc-13, clang-17, MSVC

🤖 Generated with [Claude Code](https://claude.com/claude-code)